### PR TITLE
fixing link at pgpool project

### DIFF
--- a/postgresql_replication.tex
+++ b/postgresql_replication.tex
@@ -24,7 +24,7 @@
 \begin{itemize}
   \item \href{http://www.slony.info/}{Slony-I}~--- асинхронная Master-Slave репликация, поддерживает каскады(cascading) и отказоустойчивость(failover). Slony-I использует триггеры PostgreSQL для привязки к событиям INSERT/DELETE/UPDATE и хранимые процедуры для выполнения действий;
 
-  \item \href{http://pgpool.projects.postgresql.org/}{Pgpool-I/II}~--- это замечательный инструмент для PostgreSQL (лучше сразу работать с II версией). Позволяет делать:
+  \item \href{http://pgpool.net/}{Pgpool-I/II}~--- это замечательный инструмент для PostgreSQL (лучше сразу работать с II версией). Позволяет делать:
   \begin{itemize}
     \item репликацию (в том числе, с автоматическим переключением на резервный stand-by сервер);
     \item online-бэкап;


### PR DESCRIPTION
Current site address of the pgpool project is: http://pgpool.net/
Current start page is http://pgpool.net/mediawiki/index.php/Main_Page